### PR TITLE
add dev-lang/sassc as build dependency

### DIFF
--- a/x11-themes/yaru/yaru-22.04.4.ebuild
+++ b/x11-themes/yaru/yaru-22.04.4.ebuild
@@ -2,9 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=6
+EAPI=8
 
-inherit meson git-r3 gnome2-utils
+inherit meson git-r3 xdg-utils
 
 DESCRIPTION="Ubuntu community theme \"yaru\"."
 HOMEPAGE="https://github.com/ubuntu/yaru"
@@ -20,7 +20,7 @@ KEYWORDS="amd64 x86"
 IUSE=""
 
 DEPEND="
-	dev-vcs/git
+    dev-vcs/git
 "
 
 BDEPEND="
@@ -28,18 +28,14 @@ BDEPEND="
 "
 
 RDEPEND="
-	x11-themes/gtk-engines-murrine
-	x11-themes/gnome-themes-standard
+    x11-themes/gtk-engines-murrine
+    x11-themes/gnome-themes-standard
 "
 
-pkg_preinst() {
-	gnome2_icon_savelist
-}
-
 pkg_postinst() {
-	gnome2_icon_cache_update
+    xdg_icon_cache_update
 }
 
 pkg_postrm() {
-	gnome2_icon_cache_update
+    xdg_icon_cache_update
 }

--- a/x11-themes/yaru/yaru-22.04.4.ebuild
+++ b/x11-themes/yaru/yaru-22.04.4.ebuild
@@ -22,6 +22,11 @@ IUSE=""
 DEPEND="
 	dev-vcs/git
 "
+
+BDEPEND="
+    dev-lang/sassc
+"
+
 RDEPEND="
 	x11-themes/gtk-engines-murrine
 	x11-themes/gnome-themes-standard


### PR DESCRIPTION
the ebuild fails because the sassc executeable is missing. also gnome2_icon_cache_update is not available anymore